### PR TITLE
Fix: Remove Scrumpy vendor namespace

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,12 +20,12 @@
     },
     "autoload": {
         "psr-4": {
-            "Scrumpy\\HtmlToProseMirror\\": "src/"
+            "HtmlToProseMirror\\": "src/"
         }
     },
     "autoload-dev": {
         "psr-4": {
-            "Scrumpy\\HtmlToProseMirror\\Test\\": "tests/"
+            "HtmlToProseMirror\\Test\\": "tests/"
         }
     },
     "scripts": {

--- a/src/Marks/Bold.php
+++ b/src/Marks/Bold.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Scrumpy\HtmlToProseMirror\Marks;
+namespace HtmlToProseMirror\Marks;
 
 class Bold extends Mark
 {

--- a/src/Marks/Code.php
+++ b/src/Marks/Code.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Scrumpy\HtmlToProseMirror\Marks;
+namespace HtmlToProseMirror\Marks;
 
 class Code extends Mark
 {

--- a/src/Marks/Italic.php
+++ b/src/Marks/Italic.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Scrumpy\HtmlToProseMirror\Marks;
+namespace HtmlToProseMirror\Marks;
 
 class Italic extends Mark
 {

--- a/src/Marks/Link.php
+++ b/src/Marks/Link.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Scrumpy\HtmlToProseMirror\Marks;
+namespace HtmlToProseMirror\Marks;
 
 class Link extends Mark
 {

--- a/src/Marks/Mark.php
+++ b/src/Marks/Mark.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Scrumpy\HtmlToProseMirror\Marks;
+namespace HtmlToProseMirror\Marks;
 
 class Mark
 {

--- a/src/Marks/Subscript.php
+++ b/src/Marks/Subscript.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Scrumpy\HtmlToProseMirror\Marks;
+namespace HtmlToProseMirror\Marks;
 
 class Subscript extends Mark
 {

--- a/src/Marks/Superscript.php
+++ b/src/Marks/Superscript.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Scrumpy\HtmlToProseMirror\Marks;
+namespace HtmlToProseMirror\Marks;
 
 class Superscript extends Mark
 {

--- a/src/Marks/Underline.php
+++ b/src/Marks/Underline.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Scrumpy\HtmlToProseMirror\Marks;
+namespace HtmlToProseMirror\Marks;
 
 class Underline extends Mark
 {

--- a/src/Nodes/Blockquote.php
+++ b/src/Nodes/Blockquote.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Scrumpy\HtmlToProseMirror\Nodes;
+namespace HtmlToProseMirror\Nodes;
 
 class Blockquote extends Node
 {

--- a/src/Nodes/BulletList.php
+++ b/src/Nodes/BulletList.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Scrumpy\HtmlToProseMirror\Nodes;
+namespace HtmlToProseMirror\Nodes;
 
 class BulletList extends Node
 {

--- a/src/Nodes/CodeBlock.php
+++ b/src/Nodes/CodeBlock.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Scrumpy\HtmlToProseMirror\Nodes;
+namespace HtmlToProseMirror\Nodes;
 
 class CodeBlock extends Node
 {

--- a/src/Nodes/CodeBlockWrapper.php
+++ b/src/Nodes/CodeBlockWrapper.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Scrumpy\HtmlToProseMirror\Nodes;
+namespace HtmlToProseMirror\Nodes;
 
 class CodeBlockWrapper extends Node
 {

--- a/src/Nodes/HardBreak.php
+++ b/src/Nodes/HardBreak.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Scrumpy\HtmlToProseMirror\Nodes;
+namespace HtmlToProseMirror\Nodes;
 
 class HardBreak extends Node
 {

--- a/src/Nodes/Heading.php
+++ b/src/Nodes/Heading.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Scrumpy\HtmlToProseMirror\Nodes;
+namespace HtmlToProseMirror\Nodes;
 
 class Heading extends Node
 {

--- a/src/Nodes/Image.php
+++ b/src/Nodes/Image.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Scrumpy\HtmlToProseMirror\Nodes;
+namespace HtmlToProseMirror\Nodes;
 
 class Image extends Node
 {

--- a/src/Nodes/ListItem.php
+++ b/src/Nodes/ListItem.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Scrumpy\HtmlToProseMirror\Nodes;
+namespace HtmlToProseMirror\Nodes;
 
 class ListItem extends Node
 {

--- a/src/Nodes/Node.php
+++ b/src/Nodes/Node.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Scrumpy\HtmlToProseMirror\Nodes;
+namespace HtmlToProseMirror\Nodes;
 
 class Node
 {

--- a/src/Nodes/OrderedList.php
+++ b/src/Nodes/OrderedList.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Scrumpy\HtmlToProseMirror\Nodes;
+namespace HtmlToProseMirror\Nodes;
 
 class OrderedList extends Node
 {

--- a/src/Nodes/Paragraph.php
+++ b/src/Nodes/Paragraph.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Scrumpy\HtmlToProseMirror\Nodes;
+namespace HtmlToProseMirror\Nodes;
 
 class Paragraph extends Node
 {

--- a/src/Nodes/Table.php
+++ b/src/Nodes/Table.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Scrumpy\HtmlToProseMirror\Nodes;
+namespace HtmlToProseMirror\Nodes;
 
 class Table extends Node
 {

--- a/src/Nodes/TableCell.php
+++ b/src/Nodes/TableCell.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Scrumpy\HtmlToProseMirror\Nodes;
+namespace HtmlToProseMirror\Nodes;
 
 class TableCell extends Node
 {

--- a/src/Nodes/TableHeader.php
+++ b/src/Nodes/TableHeader.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Scrumpy\HtmlToProseMirror\Nodes;
+namespace HtmlToProseMirror\Nodes;
 
 class TableHeader extends TableCell
 {

--- a/src/Nodes/TableRow.php
+++ b/src/Nodes/TableRow.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Scrumpy\HtmlToProseMirror\Nodes;
+namespace HtmlToProseMirror\Nodes;
 
 class TableRow extends Node
 {

--- a/src/Nodes/TableWrapper.php
+++ b/src/Nodes/TableWrapper.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Scrumpy\HtmlToProseMirror\Nodes;
+namespace HtmlToProseMirror\Nodes;
 
 class TableWrapper extends Node
 {

--- a/src/Nodes/Text.php
+++ b/src/Nodes/Text.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Scrumpy\HtmlToProseMirror\Nodes;
+namespace HtmlToProseMirror\Nodes;
 
 class Text extends Node
 {

--- a/src/Nodes/User.php
+++ b/src/Nodes/User.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Scrumpy\HtmlToProseMirror\Nodes;
+namespace HtmlToProseMirror\Nodes;
 
 class User extends Node
 {

--- a/src/Renderer.php
+++ b/src/Renderer.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Scrumpy\HtmlToProseMirror;
+namespace HtmlToProseMirror;
 
 use DOMElement;
 use DOMDocument;

--- a/tests/EmojiTest.php
+++ b/tests/EmojiTest.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Scrumpy\HtmlToProseMirror\Test;
+namespace HtmlToProseMirror\Test;
 
-use Scrumpy\HtmlToProseMirror\Renderer;
+use HtmlToProseMirror\Renderer;
 
 class EmojiTest extends TestCase
 {

--- a/tests/EmptyTextNodesTest.php
+++ b/tests/EmptyTextNodesTest.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Scrumpy\HtmlToProseMirror\Test;
+namespace HtmlToProseMirror\Test;
 
-use Scrumpy\HtmlToProseMirror\Renderer;
+use HtmlToProseMirror\Renderer;
 
 class EmptyTextNodesTest extends TestCase
 {

--- a/tests/Marks/BoldTest.php
+++ b/tests/Marks/BoldTest.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Scrumpy\HtmlToProseMirror\Test\Nodes;
+namespace HtmlToProseMirror\Test\Nodes;
 
-use Scrumpy\HtmlToProseMirror\Renderer;
-use Scrumpy\HtmlToProseMirror\Test\TestCase;
+use HtmlToProseMirror\Renderer;
+use HtmlToProseMirror\Test\TestCase;
 
 class BoldTest extends TestCase
 {

--- a/tests/Marks/CodeTest.php
+++ b/tests/Marks/CodeTest.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Scrumpy\HtmlToProseMirror\Test\Nodes;
+namespace HtmlToProseMirror\Test\Nodes;
 
-use Scrumpy\HtmlToProseMirror\Renderer;
-use Scrumpy\HtmlToProseMirror\Test\TestCase;
+use HtmlToProseMirror\Renderer;
+use HtmlToProseMirror\Test\TestCase;
 
 class CodeTest extends TestCase
 {

--- a/tests/Marks/ImageTest.php
+++ b/tests/Marks/ImageTest.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Scrumpy\HtmlToProseMirror\Test\Nodes;
+namespace HtmlToProseMirror\Test\Nodes;
 
-use Scrumpy\HtmlToProseMirror\Renderer;
-use Scrumpy\HtmlToProseMirror\Test\TestCase;
+use HtmlToProseMirror\Renderer;
+use HtmlToProseMirror\Test\TestCase;
 
 class ImageTest extends TestCase
 {

--- a/tests/Marks/ItalicTest.php
+++ b/tests/Marks/ItalicTest.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Scrumpy\HtmlToProseMirror\Test\Nodes;
+namespace HtmlToProseMirror\Test\Nodes;
 
-use Scrumpy\HtmlToProseMirror\Renderer;
-use Scrumpy\HtmlToProseMirror\Test\TestCase;
+use HtmlToProseMirror\Renderer;
+use HtmlToProseMirror\Test\TestCase;
 
 class ItalicTest extends TestCase
 {

--- a/tests/Marks/LinkTest.php
+++ b/tests/Marks/LinkTest.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Scrumpy\HtmlToProseMirror\Test\Nodes;
+namespace HtmlToProseMirror\Test\Nodes;
 
-use Scrumpy\HtmlToProseMirror\Renderer;
-use Scrumpy\HtmlToProseMirror\Test\TestCase;
+use HtmlToProseMirror\Renderer;
+use HtmlToProseMirror\Test\TestCase;
 
 class LinkTest extends TestCase
 {

--- a/tests/Marks/NestedMarksTest.php
+++ b/tests/Marks/NestedMarksTest.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Scrumpy\HtmlToProseMirror\Test\Nodes;
+namespace HtmlToProseMirror\Test\Nodes;
 
-use Scrumpy\HtmlToProseMirror\Renderer;
-use Scrumpy\HtmlToProseMirror\Test\TestCase;
+use HtmlToProseMirror\Renderer;
+use HtmlToProseMirror\Test\TestCase;
 
 class NestedMarksTest extends TestCase
 {

--- a/tests/Marks/SubscriptTest.php
+++ b/tests/Marks/SubscriptTest.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Scrumpy\HtmlToProseMirror\Test\Nodes;
+namespace HtmlToProseMirror\Test\Nodes;
 
-use Scrumpy\HtmlToProseMirror\Renderer;
-use Scrumpy\HtmlToProseMirror\Test\TestCase;
+use HtmlToProseMirror\Renderer;
+use HtmlToProseMirror\Test\TestCase;
 
 class SubscriptTest extends TestCase
 {

--- a/tests/Marks/SuperscriptTest.php
+++ b/tests/Marks/SuperscriptTest.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Scrumpy\HtmlToProseMirror\Test\Nodes;
+namespace HtmlToProseMirror\Test\Nodes;
 
-use Scrumpy\HtmlToProseMirror\Renderer;
-use Scrumpy\HtmlToProseMirror\Test\TestCase;
+use HtmlToProseMirror\Renderer;
+use HtmlToProseMirror\Test\TestCase;
 
 class SuperscriptTest extends TestCase
 {

--- a/tests/Marks/UnderlineTest.php
+++ b/tests/Marks/UnderlineTest.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Scrumpy\HtmlToProseMirror\Test\Nodes;
+namespace HtmlToProseMirror\Test\Nodes;
 
-use Scrumpy\HtmlToProseMirror\Renderer;
-use Scrumpy\HtmlToProseMirror\Test\TestCase;
+use HtmlToProseMirror\Renderer;
+use HtmlToProseMirror\Test\TestCase;
 
 class UnderlineTest extends TestCase
 {

--- a/tests/Mix/MarksInNodesTest.php
+++ b/tests/Mix/MarksInNodesTest.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Scrumpy\HtmlToProseMirror\Test\Mix;
+namespace HtmlToProseMirror\Test\Mix;
 
-use Scrumpy\HtmlToProseMirror\Renderer;
-use Scrumpy\HtmlToProseMirror\Test\TestCase;
+use HtmlToProseMirror\Renderer;
+use HtmlToProseMirror\Test\TestCase;
 
 class MarksInNodesTest extends TestCase
 {

--- a/tests/Mix/MultipleMarksTest.php
+++ b/tests/Mix/MultipleMarksTest.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Scrumpy\HtmlToProseMirror\Test\Mix;
+namespace HtmlToProseMirror\Test\Mix;
 
-use Scrumpy\HtmlToProseMirror\Renderer;
-use Scrumpy\HtmlToProseMirror\Test\TestCase;
+use HtmlToProseMirror\Renderer;
+use HtmlToProseMirror\Test\TestCase;
 
 class MultipleMarksTest extends TestCase
 {

--- a/tests/Nodes/BlockquoteTest.php
+++ b/tests/Nodes/BlockquoteTest.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Scrumpy\HtmlToProseMirror\Test\Nodes;
+namespace HtmlToProseMirror\Test\Nodes;
 
-use Scrumpy\HtmlToProseMirror\Renderer;
-use Scrumpy\HtmlToProseMirror\Test\TestCase;
+use HtmlToProseMirror\Renderer;
+use HtmlToProseMirror\Test\TestCase;
 
 class BlockquoteTest extends TestCase
 {

--- a/tests/Nodes/BulletListTest.php
+++ b/tests/Nodes/BulletListTest.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Scrumpy\HtmlToProseMirror\Test\Nodes;
+namespace HtmlToProseMirror\Test\Nodes;
 
-use Scrumpy\HtmlToProseMirror\Renderer;
-use Scrumpy\HtmlToProseMirror\Test\TestCase;
+use HtmlToProseMirror\Renderer;
+use HtmlToProseMirror\Test\TestCase;
 
 class BulletListTest extends TestCase
 {

--- a/tests/Nodes/CodeBlockTest.php
+++ b/tests/Nodes/CodeBlockTest.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Scrumpy\HtmlToProseMirror\Test\Nodes;
+namespace HtmlToProseMirror\Test\Nodes;
 
-use Scrumpy\HtmlToProseMirror\Renderer;
-use Scrumpy\HtmlToProseMirror\Test\TestCase;
+use HtmlToProseMirror\Renderer;
+use HtmlToProseMirror\Test\TestCase;
 
 class CodeBlockTest extends TestCase
 {

--- a/tests/Nodes/HardBreakTest.php
+++ b/tests/Nodes/HardBreakTest.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Scrumpy\HtmlToProseMirror\Test\Nodes;
+namespace HtmlToProseMirror\Test\Nodes;
 
-use Scrumpy\HtmlToProseMirror\Renderer;
-use Scrumpy\HtmlToProseMirror\Test\TestCase;
+use HtmlToProseMirror\Renderer;
+use HtmlToProseMirror\Test\TestCase;
 
 class HardBreakTest extends TestCase
 {

--- a/tests/Nodes/HeadingTest.php
+++ b/tests/Nodes/HeadingTest.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Scrumpy\HtmlToProseMirror\Test\Nodes;
+namespace HtmlToProseMirror\Test\Nodes;
 
-use Scrumpy\HtmlToProseMirror\Renderer;
-use Scrumpy\HtmlToProseMirror\Test\TestCase;
+use HtmlToProseMirror\Renderer;
+use HtmlToProseMirror\Test\TestCase;
 
 class HeadingTest extends TestCase
 {

--- a/tests/Nodes/OrderedListTest.php
+++ b/tests/Nodes/OrderedListTest.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Scrumpy\HtmlToProseMirror\Test\Nodes;
+namespace HtmlToProseMirror\Test\Nodes;
 
-use Scrumpy\HtmlToProseMirror\Renderer;
-use Scrumpy\HtmlToProseMirror\Test\TestCase;
+use HtmlToProseMirror\Renderer;
+use HtmlToProseMirror\Test\TestCase;
 
 class OrderedListTest extends TestCase
 {

--- a/tests/Nodes/ParagraphTest.php
+++ b/tests/Nodes/ParagraphTest.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Scrumpy\HtmlToProseMirror\Test\Nodes;
+namespace HtmlToProseMirror\Test\Nodes;
 
-use Scrumpy\HtmlToProseMirror\Renderer;
-use Scrumpy\HtmlToProseMirror\Test\TestCase;
+use HtmlToProseMirror\Renderer;
+use HtmlToProseMirror\Test\TestCase;
 
 class ParagraphTest extends TestCase
 {

--- a/tests/Nodes/TableTest.php
+++ b/tests/Nodes/TableTest.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Scrumpy\HtmlToProseMirror\Test\Nodes;
+namespace HtmlToProseMirror\Test\Nodes;
 
-use Scrumpy\HtmlToProseMirror\Renderer;
-use Scrumpy\HtmlToProseMirror\Test\TestCase;
+use HtmlToProseMirror\Renderer;
+use HtmlToProseMirror\Test\TestCase;
 
 class TableTest extends TestCase
 {

--- a/tests/Nodes/UserMentionTest.php
+++ b/tests/Nodes/UserMentionTest.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Scrumpy\HtmlToProseMirror\Test\Nodes;
+namespace HtmlToProseMirror\Test\Nodes;
 
-use Scrumpy\HtmlToProseMirror\Renderer;
-use Scrumpy\HtmlToProseMirror\Test\TestCase;
+use HtmlToProseMirror\Renderer;
+use HtmlToProseMirror\Test\TestCase;
 
 class UserMentionTest extends TestCase
 {

--- a/tests/SpecialCharacterTest.php
+++ b/tests/SpecialCharacterTest.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Scrumpy\HtmlToProseMirror\Test;
+namespace HtmlToProseMirror\Test;
 
-use Scrumpy\HtmlToProseMirror\Renderer;
+use HtmlToProseMirror\Renderer;
 
 class SpecialCharacterTest extends TestCase
 {

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Scrumpy\HtmlToProseMirror\Test;
+namespace HtmlToProseMirror\Test;
 
 use League\CLImate\CLImate;
 use PHPUnit\Framework\TestCase as BaseTestCase;

--- a/tests/WhitespaceTest.php
+++ b/tests/WhitespaceTest.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Scrumpy\HtmlToProseMirror\Test;
+namespace HtmlToProseMirror\Test;
 
-use Scrumpy\HtmlToProseMirror\Renderer;
+use HtmlToProseMirror\Renderer;
 
 class WhitespaceTest extends TestCase
 {


### PR DESCRIPTION
This PR

* [x] removes the `Scrumpy` vendor namespace

Fixes #11.