### PR TITLE
add ability to use custom nodes and marks

### DIFF
--- a/src/Renderer.php
+++ b/src/Renderer.php
@@ -160,4 +160,58 @@ class Renderer
 
         return false;
     }
+
+    public function addNode($node)
+    {
+        $this->nodes[] = $node;
+
+        return $this;
+    }
+
+    public function addNodes($nodes)
+    {
+        foreach ($nodes as $node) {
+            $this->addNode($node);
+        }
+
+        return $this;
+    }
+
+    public function addMark($mark)
+    {
+        $this->marks[] = $mark;
+
+        return $this;
+    }
+
+    public function addMarks($marks)
+    {
+        foreach ($marks as $mark) {
+            $this->addMark($mark);
+        }
+
+        return $this;
+    }
+
+    public function replaceNode($search_node, $replace_node)
+    {
+        foreach ($this->nodes as $key => $node_class) {
+            if ($node_class == $search_node) {
+                $this->nodes[$key] = $replace_node;
+            }
+        }
+
+        return $this;
+    }
+
+    public function replaceMark($search_mark, $replace_mark)
+    {
+        foreach ($this->marks as $key => $mark_class) {
+            if ($mark_class == $search_mark) {
+                $this->marks[$key] = $replace_mark;
+            }
+        }
+
+        return $this;
+    }
 }

--- a/tests/Marks/Custom.php
+++ b/tests/Marks/Custom.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace HtmlToProseMirror\Test\Marks;
+
+use HtmlToProseMirror\Marks\Mark;
+
+class Custom extends Mark
+{
+    public function matching()
+    {
+        return $this->DOMNode->nodeName === 'span';
+    }
+
+    public function data()
+    {
+        $data = [
+            'type' => 'custom',
+        ];
+
+        $attrs = [];
+
+        if ($foo = $this->DOMNode->getAttribute('data-foo')) {
+            $attrs['foo'] = $foo;
+        }
+
+        if ($bar = $this->DOMNode->getAttribute('bar')) {
+            $attrs['bar'] = $bar;
+        }
+
+        $data['attrs'] = $attrs;
+
+        return $data;
+    }
+}

--- a/tests/Marks/CustomMarkTest.php
+++ b/tests/Marks/CustomMarkTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace HtmlToProseMirror\Test\Marks;
+
+use HtmlToProseMirror\Renderer;
+use HtmlToProseMirror\Test\TestCase;
+
+class CustomMarkTest extends TestCase
+{
+    /** @test */
+    public function b_and_strong_get_rendered_correctly()
+    {
+        $html = '<p><span data-foo="bla bla" bar="nanana">Example text inside custom mark</span> and some more text.</p>';
+
+        $json = [
+            'type'    => 'doc',
+            'content' => [
+                [
+                    'type'    => 'paragraph',
+                    'content' => [
+                        [
+                            'type'  => 'text',
+                            'text'  => 'Example text inside custom mark',
+                            'marks' => [
+                                [
+                                    'type' => 'custom',
+                                    'attrs' => [
+                                        'foo' => 'bla bla',
+                                        'bar' => 'nanana',
+                                    ]
+                                ],
+                            ],
+                        ],
+                        [
+                            'type' => 'text',
+                            'text' => ' and some more text.',
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $renderer = (new Renderer())->addMark(Custom::class);
+
+        $this->assertEquals($json, $renderer->render($html));
+    }
+}

--- a/tests/Marks/CustomMarkTest.php
+++ b/tests/Marks/CustomMarkTest.php
@@ -27,7 +27,7 @@ class CustomMarkTest extends TestCase
                                     'attrs' => [
                                         'foo' => 'bla bla',
                                         'bar' => 'nanana',
-                                    ]
+                                    ],
                                 ],
                             ],
                         ],

--- a/tests/Nodes/Custom.php
+++ b/tests/Nodes/Custom.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace HtmlToProseMirror\Test\Nodes;
+
+use HtmlToProseMirror\Nodes\Node;
+
+class Custom extends Node
+{
+    public function matching()
+    {
+        return $this->DOMNode->nodeName === 'span';
+    }
+
+    public function data()
+    {
+        $data = [
+            'type' => 'custom',
+        ];
+
+        $attrs = [];
+
+        if ($foo = $this->DOMNode->getAttribute('data-foo')) {
+            $attrs['foo'] = $foo;
+        }
+
+        if ($bar = $this->DOMNode->getAttribute('bar')) {
+            $attrs['bar'] = $bar;
+        }
+
+        $data['attrs'] = $attrs;
+
+        return $data;
+    }
+}

--- a/tests/Nodes/CustomNodeTest.php
+++ b/tests/Nodes/CustomNodeTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace HtmlToProseMirror\Test\Nodes;
+
+use HtmlToProseMirror\Renderer;
+use HtmlToProseMirror\Test\TestCase;
+
+class CustomNodeTest extends TestCase
+{
+    /** @test */
+    public function b_and_strong_get_rendered_correctly()
+    {
+        $html = '<p>A custom node <span data-foo="bla bla" bar="nanana"></span> and some normal text.</p>';
+
+        $json = [
+            'type'    => 'doc',
+            'content' => [
+                [
+                    'type'    => 'paragraph',
+                    'content' => [
+                        [
+                            'type'  => 'text',
+                            'text'  => 'A custom node ',
+                        ],
+                        [
+                            'type' => 'custom',
+                            'attrs' => [
+                                'foo' => 'bla bla',
+                                'bar' => 'nanana',
+                            ],
+                        ],
+                        [
+                            'type' => 'text',
+                            'text' => ' and some normal text.',
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $renderer = (new Renderer())->addNode(Custom::class);
+
+        $this->assertEquals($json, $renderer->render($html));
+    }
+}


### PR DESCRIPTION
This PR adds the methods necessary to use custom Node and Mark classes when converting HTML to Prosemirror JSON.

This is already supported the other way around in https://github.com/ueberdosis/prosemirror-to-html.