### PR TITLE
Add horizontal rule

### DIFF
--- a/src/Nodes/HorizontalRule.php
+++ b/src/Nodes/HorizontalRule.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace HtmlToProseMirror\Nodes;
+
+class HorizontalRule extends Node
+{
+    public function matching()
+    {
+        return $this->DOMNode->nodeName === 'hr';
+    }
+
+    public function data()
+    {
+        return [
+            'type' => 'horizontal_rule',
+        ];
+    }
+}

--- a/src/Renderer.php
+++ b/src/Renderer.php
@@ -30,6 +30,7 @@ class Renderer
         Nodes\CodeBlockWrapper::class,
         Nodes\HardBreak::class,
         Nodes\Heading::class,
+        Nodes\HorizontalRule::class,
         Nodes\Image::class,
         Nodes\ListItem::class,
         Nodes\OrderedList::class,

--- a/tests/Nodes/HorizontalRuleTest.php
+++ b/tests/Nodes/HorizontalRuleTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace HtmlToProseMirror\Test\Nodes;
+
+use HtmlToProseMirror\Renderer;
+use HtmlToProseMirror\Test\TestCase;
+
+class HorizontalRuleTest extends TestCase
+{
+    /** @test */
+    public function hr_gets_rendered_correctly()
+    {
+        $html = '<p>Horizontal</p><hr /><p>Rule</p>';
+
+        $json = [
+            'type' => 'doc',
+            'content' => [
+                [
+                    'type' => 'paragraph',
+                    'content' => [
+                        [
+                            'type' => 'text',
+                            'text' => 'Horizontal',
+                        ],
+                    ],
+                ],
+                [
+                    'type' => 'horizontal_rule',
+                ],
+                [
+                    'type' => 'paragraph',
+                    'content' => [
+                        [
+                            'type' => 'text',
+                            'text' => 'Rule',
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $this->assertEquals($json, (new Renderer)->render($html));
+    }
+}


### PR DESCRIPTION
This adds support for `<hr>` tags.

However, the test doesn't pass. I'm not sure what needs to be done.

You should be able to have an `hr` inside a `p`, right? That test doesn't pass.
e.g. `<p>foo<hr>bar</p>`. 

`hr` outside of a `p` seems to be ok.
e.g. `<p>foo</p><hr><p>bar</p>`